### PR TITLE
fix(mpris): show GNOME media-controls widget + cover art

### DIFF
--- a/src/mpris/server.rs
+++ b/src/mpris/server.rs
@@ -7,18 +7,23 @@ use mpris_server::{
     LoopStatus, Metadata, PlaybackRate, PlaybackStatus, PlayerInterface, Property, RootInterface,
     Server, Time, TrackId, Volume,
 };
+use tempfile::NamedTempFile;
+use tokio::sync::Mutex;
 use tracing::info;
 use url::Url;
 
 use crate::app::state::{SharedClientState, SharedDaemonState};
 use crate::config::Config;
 use crate::daemon::state::{NowPlaying, PlaybackState};
-use crate::ipc::{DaemonClient, DaemonRequest};
+use crate::ipc::{DaemonClient, DaemonRequest, DaemonResponse};
 use crate::subsonic::auth::generate_auth_params;
 use crate::subsonic::models::Child;
 
 const API_VERSION: &str = "1.16.1";
 const CLIENT_NAME: &str = "ferrosonic";
+
+/// Edge length, in pixels, of the cover art fetched for MPRIS metadata.
+const MPRIS_COVER_SIZE: u32 = 512;
 
 /// Authenticated getCoverArt URL for MPRIS metadata; None when unconfigured.
 #[must_use]
@@ -43,6 +48,15 @@ pub fn build_cover_art_url(config: &Config, cover_art_id: &str) -> Option<String
 
 const PLAYER_NAME: &str = "ferrosonic";
 
+/// Locally cached cover for one art id, kept so the `file://` URL handed to
+/// MPRIS consumers stays valid until the track (and thus its art) changes.
+struct CoverCache {
+    /// Cover art id the file currently holds.
+    cover_id: String,
+    /// Tempfile backing the `file://` URL; deletes itself when replaced.
+    file: NamedTempFile,
+}
+
 /// MPRIS2 player implementation bridging D-Bus to the daemon client.
 pub struct MprisPlayer {
     daemon_state: SharedDaemonState,
@@ -53,6 +67,10 @@ pub struct MprisPlayer {
     /// panics with "no reactor"; spawning through this handle runs the
     /// daemon request (which needs tokio I/O) on a real tokio worker.
     rt: tokio::runtime::Handle,
+    /// Cover art mirrored to a local file. GNOME Shell's media-controls
+    /// widget won't fetch the remote authenticated Subsonic URL, but it
+    /// loads a `file://` reliably (same as our desktop notifications).
+    cover_cache: Mutex<Option<CoverCache>>,
 }
 
 impl MprisPlayer {
@@ -67,7 +85,51 @@ impl MprisPlayer {
             client_state,
             client,
             rt: tokio::runtime::Handle::current(),
+            cover_cache: Mutex::new(None),
         }
+    }
+
+    /// Mirror the cover for `cover_id` to a local file and return its
+    /// `file://` URL, reusing the cached file when the id is unchanged.
+    /// Returns `None` if the fetch yields no bytes or the write fails;
+    /// callers then fall back to the remote art URL.
+    ///
+    /// The lock spans the fetch+write so concurrent metadata pushes for the
+    /// same track don't double-fetch or race on the shared tempfile.
+    #[allow(clippy::significant_drop_tightening)]
+    async fn cover_file_uri(&self, cover_id: &str) -> Option<String> {
+        let mut guard = self.cover_cache.lock().await;
+        if let Some(cache) = guard.as_ref() {
+            if cache.cover_id == cover_id {
+                return Some(format!("file://{}", cache.file.path().display()));
+            }
+        }
+
+        let bytes = match self
+            .client
+            .request(DaemonRequest::FetchCoverArt {
+                id: cover_id.to_string(),
+                size: MPRIS_COVER_SIZE,
+            })
+            .await
+        {
+            Ok(DaemonResponse::CoverArt(bytes)) if !bytes.is_empty() => bytes,
+            _ => return None,
+        };
+
+        let file = NamedTempFile::with_prefix("ferrosonic-mpris-").ok()?;
+        let path = file.path().to_path_buf();
+        tokio::task::spawn_blocking(move || crate::io_util::atomic_write_bytes(&path, &bytes))
+            .await
+            .ok()?
+            .ok()?;
+
+        let uri = format!("file://{}", file.path().display());
+        *guard = Some(CoverCache {
+            cover_id: cover_id.to_string(),
+            file,
+        });
+        Some(uri)
     }
 
     /// Dispatch a fire-and-forget daemon request onto the captured tokio runtime. Errors are logged, not propagated, since D-Bus media keys expect no reply.
@@ -365,6 +427,9 @@ pub struct MprisPropertySnapshot {
     /// consumers (e.g. GNOME Shell) cache `CanPlay` from the initial read
     /// and only refresh it via `PropertiesChanged`, so it must be pushed.
     pub can_play: bool,
+    /// Cover art id of the current song, if any. Used to mirror the art to a
+    /// local file so the pushed `Metadata` carries a loadable `file://` URL.
+    pub cover_id: Option<String>,
     /// Track metadata, when a song is loaded.
     pub metadata: Option<Metadata>,
 }
@@ -391,6 +456,7 @@ pub async fn build_property_snapshot(daemon_state: &SharedDaemonState) -> MprisP
         )
     };
 
+    let cover_id = current_song.as_ref().and_then(Child::cover_id);
     let metadata = current_song.map(|song| build_metadata_for(&song, &config));
 
     MprisPropertySnapshot {
@@ -398,6 +464,7 @@ pub async fn build_property_snapshot(daemon_state: &SharedDaemonState) -> MprisP
         can_go_next,
         can_go_prev,
         can_play,
+        cover_id,
         metadata,
     }
 }
@@ -445,7 +512,13 @@ pub async fn update_mpris_properties(
         ])
         .await?;
 
-    if let Some(metadata) = snap.metadata {
+    if let Some(mut metadata) = snap.metadata {
+        // Swap the remote art URL for a local file:// the widget can load.
+        if let Some(cid) = &snap.cover_id {
+            if let Some(file_url) = server.imp().cover_file_uri(cid).await {
+                metadata.set_art_url(Some(file_url));
+            }
+        }
         server
             .properties_changed([Property::Metadata(metadata)])
             .await?;

--- a/src/mpris/server.rs
+++ b/src/mpris/server.rs
@@ -259,6 +259,10 @@ impl PlayerInterface for MprisPlayer {
                 metadata.set_disc_number(Some(disc));
             }
 
+            // Remote (authenticated) URL only. The local file:// swap happens in
+            // `update_mpris_properties`, which runs on the tokio runtime; doing
+            // the fetch here would run on zbus's executor where daemon I/O has
+            // no reactor (the same reason `fire` exists).
             if let Some(ref cover_art_id) = song.cover_art {
                 if let Some(cover_url) = build_cover_art_url(&config, cover_art_id) {
                     metadata.set_art_url(Some(cover_url));
@@ -357,13 +361,17 @@ pub struct MprisPropertySnapshot {
     pub can_go_next: bool,
     /// Whether a previous track exists.
     pub can_go_prev: bool,
+    /// Whether playback is possible (queue non-empty). Event-driven MPRIS
+    /// consumers (e.g. GNOME Shell) cache `CanPlay` from the initial read
+    /// and only refresh it via `PropertiesChanged`, so it must be pushed.
+    pub can_play: bool,
     /// Track metadata, when a song is loaded.
     pub metadata: Option<Metadata>,
 }
 
 /// Pure: builds the property snapshot from daemon state.
 pub async fn build_property_snapshot(daemon_state: &SharedDaemonState) -> MprisPropertySnapshot {
-    let (playback, can_go_next, can_go_prev, current_song, config) = {
+    let (playback, can_go_next, can_go_prev, can_play, current_song, config) = {
         let ds = daemon_state.read().await;
         let pb = match ds.now_playing.state {
             PlaybackState::Playing => PlaybackStatus::Playing,
@@ -372,7 +380,15 @@ pub async fn build_property_snapshot(daemon_state: &SharedDaemonState) -> MprisP
         };
         let cgn = ds.queue_position.is_some_and(|p| p + 1 < ds.queue.len());
         let cgp = ds.queue_position.is_some_and(|p| p > 0);
-        (pb, cgn, cgp, ds.current_song().cloned(), ds.config.clone())
+        let cp = !ds.queue.is_empty();
+        (
+            pb,
+            cgn,
+            cgp,
+            cp,
+            ds.current_song().cloned(),
+            ds.config.clone(),
+        )
     };
 
     let metadata = current_song.map(|song| build_metadata_for(&song, &config));
@@ -381,6 +397,7 @@ pub async fn build_property_snapshot(daemon_state: &SharedDaemonState) -> MprisP
         playback,
         can_go_next,
         can_go_prev,
+        can_play,
         metadata,
     }
 }
@@ -424,6 +441,7 @@ pub async fn update_mpris_properties(
             Property::PlaybackStatus(snap.playback),
             Property::CanGoNext(snap.can_go_next),
             Property::CanGoPrevious(snap.can_go_prev),
+            Property::CanPlay(snap.can_play),
         ])
         .await?;
 

--- a/tests/mpris_property_snapshot.rs
+++ b/tests/mpris_property_snapshot.rs
@@ -212,6 +212,37 @@ async fn can_play_true_when_queue_non_empty() {
 
 #[tokio::test]
 #[serial]
+async fn cover_id_none_when_song_has_no_cover_art() {
+    let ds = new_shared_daemon_state(Config::new());
+    {
+        let mut s = ds.write().await;
+        let sng = song("a", "Track");
+        s.queue.push(sng.clone());
+        s.queue_position = Some(0);
+        s.now_playing.song = Some(sng);
+    }
+    let snap = build_property_snapshot(&ds).await;
+    assert!(snap.cover_id.is_none());
+}
+
+#[tokio::test]
+#[serial]
+async fn cover_id_set_from_current_song_cover_art() {
+    let ds = new_shared_daemon_state(Config::new());
+    {
+        let mut s = ds.write().await;
+        let mut sng = song("a", "Track");
+        sng.cover_art = Some("art-7".into());
+        s.queue.push(sng.clone());
+        s.queue_position = Some(0);
+        s.now_playing.song = Some(sng);
+    }
+    let snap = build_property_snapshot(&ds).await;
+    assert_eq!(snap.cover_id.as_deref(), Some("art-7"));
+}
+
+#[tokio::test]
+#[serial]
 async fn last_position_in_queue_has_no_next_but_has_prev() {
     let ds = new_shared_daemon_state(Config::new());
     {

--- a/tests/mpris_property_snapshot.rs
+++ b/tests/mpris_property_snapshot.rs
@@ -191,6 +191,27 @@ async fn metadata_includes_artist_and_album_when_set() {
 
 #[tokio::test]
 #[serial]
+async fn can_play_false_when_queue_empty() {
+    let ds = new_shared_daemon_state(Config::new());
+    let snap = build_property_snapshot(&ds).await;
+    assert!(!snap.can_play);
+}
+
+#[tokio::test]
+#[serial]
+async fn can_play_true_when_queue_non_empty() {
+    let ds = new_shared_daemon_state(Config::new());
+    {
+        let mut s = ds.write().await;
+        s.queue = vec![song("a", "A")];
+        s.queue_position = Some(0);
+    }
+    let snap = build_property_snapshot(&ds).await;
+    assert!(snap.can_play);
+}
+
+#[tokio::test]
+#[serial]
 async fn last_position_in_queue_has_no_next_but_has_prev() {
     let ds = new_shared_daemon_state(Config::new());
     {


### PR DESCRIPTION
Two related fixes for the MPRIS2 media-controls widget in GNOME (see #31).

**1. CanPlay never pushed via PropertiesChanged**
GNOME reads `CanPlay` once when it builds the proxy (queue empty → false) and
afterwards refreshes it only from `PropertiesChanged`. We emitted
`PlaybackStatus` / `CanGoNext` / `CanGoPrevious` / `Metadata` but never
`CanPlay`, so GNOME cached `false` forever and the widget never appeared. Any
spec-compliant, caching consumer hits the same bug. Now `Property::CanPlay` is
included in the pushed set.

**2. Cover art used a remote authenticated URL**
`mpris:artUrl` pointed at the remote Subsonic getCoverArt URL, which the GNOME
widget won't load (remote + credentials). Desktop notifications already work
because they mirror the cover to a local tempfile and pass a `file://` path —
so MPRIS now does the same: fetch the cover bytes via the daemon client, cache
them to a tempfile, and hand out a `file://` URL.

Both fixes are covered by tests in `tests/mpris_property_snapshot.rs`.
`cargo fmt` + clippy gates pass locally. Verified live on GNOME Shell 50.1 /
Wayland.

Closes #31